### PR TITLE
Host Application Quiz + Host Rank Badge

### DIFF
--- a/apidocs/api.yaml
+++ b/apidocs/api.yaml
@@ -468,6 +468,250 @@ components:
       example:
         id: 100
         displayName: CutClean
+    HostApplicationResponse:
+      type: object
+      required:
+        - id
+        - username
+        - created
+        - status
+      properties:
+        id:
+          type: integer
+          description: The unique ID of this application
+        username:
+          type: string
+          description: The username of the applicant
+        created:
+          type: string
+          description: The date + time the application was submitted
+        status:
+          type: string
+          enum:
+            - pending
+            - approved
+            - declined
+          description: The current status of the application
+        reviewedBy:
+          type: string
+          description: Username of whoever reviewed this application, only present once reviewed
+        reviewedAt:
+          type: string
+          description: The date + time the application was reviewed, only present once reviewed
+        reviewReason:
+          type: string
+          description: The reason given by the reviewer, only ever present when `status` is `declined`
+      example:
+        id: 1
+        username: test
+        created: '2017-08-10T09:11:22.031Z'
+        status: declined
+        reviewedBy: ghowden
+        reviewedAt: '2017-08-11T09:11:22.031Z'
+        reviewReason: Did not answer the rules question correctly
+    HostApplicationAnswerResponse:
+      type: object
+      required:
+        - questionPrompt
+        - questionType
+      properties:
+        questionPrompt:
+          type: string
+          description: The prompt of the question at the time it was answered
+        questionType:
+          type: string
+          enum:
+            - multiple choice
+            - text
+        choiceText:
+          type: string
+          description: The text of the choice picked, only present for `multiple choice` questions
+        choiceCorrect:
+          type: boolean
+          description: Whether the picked choice was correct. Only ever present when requested with a `hosting advisor` token, otherwise omitted
+        textAnswer:
+          type: string
+          description: The free-text answer given, only present for `text` questions
+      example:
+        questionPrompt: What is the maximum allowed border size?
+        questionType: multiple choice
+        choiceText: '1500'
+        choiceCorrect: true
+    HostApplicationDetailsResponse:
+      allOf:
+        - $ref: '#/components/schemas/HostApplicationResponse'
+        - type: object
+          required:
+            - answers
+          properties:
+            answers:
+              type: array
+              items:
+                $ref: '#/components/schemas/HostApplicationAnswerResponse'
+    CreateHostApplicationRequest:
+      type: object
+      required:
+        - answers
+      properties:
+        answers:
+          type: array
+          items:
+            type: object
+            required:
+              - questionId
+            properties:
+              questionId:
+                type: integer
+                description: The ID of the quiz question being answered
+              choiceId:
+                type: integer
+                description: The ID of the choice picked, required for `multiple choice` questions
+              textAnswer:
+                type: string
+                description: The free-text answer, required for `text` questions
+      example:
+        answers:
+          - questionId: 1
+            choiceId: 3
+          - questionId: 2
+            textAnswer: My answer to the question
+    ReviewHostApplicationRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: The reason for the decision, required (and must be non-blank) when declining an application, ignored when approving
+      example:
+        reason: Did not answer the rules question correctly
+    QuizQuestionChoiceResponse:
+      type: object
+      required:
+        - id
+        - text
+      properties:
+        id:
+          type: integer
+          description: The unique ID of this choice
+        text:
+          type: string
+          description: The text shown for this choice
+    QuizQuestionResponse:
+      type: object
+      required:
+        - id
+        - prompt
+        - questionType
+        - choices
+      properties:
+        id:
+          type: integer
+          description: The unique ID of this question
+        prompt:
+          type: string
+          description: The question being asked
+        questionType:
+          type: string
+          enum:
+            - multiple choice
+            - text
+        choices:
+          type: array
+          description: Only populated for `multiple choice` questions
+          items:
+            $ref: '#/components/schemas/QuizQuestionChoiceResponse'
+      example:
+        id: 1
+        prompt: What is the maximum allowed border size?
+        questionType: multiple choice
+        choices:
+          - id: 1
+            text: '1000'
+          - id: 2
+            text: '1500'
+    QuizQuestionManageChoiceResponse:
+      type: object
+      required:
+        - id
+        - text
+        - correct
+      properties:
+        id:
+          type: integer
+          description: The unique ID of this choice
+        text:
+          type: string
+          description: The text shown for this choice
+        correct:
+          type: boolean
+          description: Whether this is the correct choice
+    QuizQuestionManageResponse:
+      type: object
+      required:
+        - id
+        - prompt
+        - questionType
+        - createdBy
+        - created
+        - choices
+      properties:
+        id:
+          type: integer
+          description: The unique ID of this question
+        prompt:
+          type: string
+          description: The question being asked
+        questionType:
+          type: string
+          enum:
+            - multiple choice
+            - text
+        createdBy:
+          type: string
+          description: Username of whoever created this question
+        created:
+          type: string
+          description: The date + time the question was created
+        choices:
+          type: array
+          description: Only populated for `multiple choice` questions
+          items:
+            $ref: '#/components/schemas/QuizQuestionManageChoiceResponse'
+    CreateQuizQuestionRequest:
+      type: object
+      required:
+        - prompt
+        - questionType
+        - choices
+      properties:
+        prompt:
+          type: string
+          description: The question being asked
+        questionType:
+          type: string
+          enum:
+            - multiple choice
+            - text
+        choices:
+          type: array
+          description: Required for `multiple choice` questions (at least 2, exactly 1 correct), must be empty for `text` questions
+          items:
+            type: object
+            required:
+              - text
+              - correct
+            properties:
+              text:
+                type: string
+              correct:
+                type: boolean
+      example:
+        prompt: What is the maximum allowed border size?
+        questionType: multiple choice
+        choices:
+          - text: '1000'
+            correct: false
+          - text: '1500'
+            correct: true
 
 paths:
   /sync:
@@ -1251,4 +1495,223 @@ paths:
           $ref: '#/components/responses/ForbiddenError'
         '404':
           description: Could not find an modifier with the given ID
+  /host-applications:
+    get:
+      tags:
+        - Host Applications
+      summary: List recent host applications
+      description: Lists the 50 most recently created host applications, most recently created first. Public endpoint
+      responses:
+        '200':
+          description: 'Successful query'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HostApplicationResponse'
+    post:
+      tags:
+        - Host Applications
+      summary: Submit a host application
+      description: Submits a new host application answering every configured quiz question. Requires the user to not already be a `host`/`trial host`, to not have the `hosting banned` permission, and to not already have a pending application
+      security:
+        - SiteApiToken: []
+        - UserApiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateHostApplicationRequest'
+      responses:
+        '201':
+          description: Created, returns the ID of the new application
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+  /host-applications/{id}:
+    get:
+      tags:
+        - Host Applications
+      summary: Get a specific host application
+      description: Returns full details of an application including submitted answers. Public endpoint, however `choiceCorrect` on each answer is only included when authenticated with a `hosting advisor` token
+      security:
+        - SiteApiToken: []
+        - UserApiToken: []
+      parameters:
+        - in: path
+          name: id
+          type: integer
+          required: true
+          description: The ID of the application
+      responses:
+        '200':
+          description: 'Successful query'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HostApplicationDetailsResponse'
+        '404':
+          description: Could not find an application with the given ID
+  /host-applications/{id}/approve:
+    post:
+      tags:
+        - Host Applications
+      summary: Approve a host application
+      description: Approves a pending application and grants the applicant the `trial host` permission, requires `hosting advisor` permission
+      security:
+        - SiteApiToken: []
+        - UserApiToken: []
+      parameters:
+        - in: path
+          name: id
+          type: integer
+          required: true
+          description: The ID of the application
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReviewHostApplicationRequest'
+      responses:
+        '200':
+          description: Approved
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: Could not find an application with the given ID
+  /host-applications/{id}/decline:
+    post:
+      tags:
+        - Host Applications
+      summary: Decline a host application
+      description: Declines a pending application, requires `hosting advisor` permission. A non-blank `reason` must be supplied in the request body
+      security:
+        - SiteApiToken: []
+        - UserApiToken: []
+      parameters:
+        - in: path
+          name: id
+          type: integer
+          required: true
+          description: The ID of the application
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ReviewHostApplicationRequest'
+      responses:
+        '200':
+          description: Declined
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          description: Could not find an application with the given ID
+  /quiz:
+    get:
+      tags:
+        - Quiz
+      summary: List quiz questions
+      description: Lists all quiz questions that must be answered to submit a host application. Public endpoint, does not indicate which choice is correct
+      responses:
+        '200':
+          description: 'Successful query'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuizQuestionResponse'
+    post:
+      tags:
+        - Quiz
+      summary: Create a quiz question
+      description: Creates a new quiz question, requires `hosting advisor` permission. `multiple choice` questions require at least 2 choices with exactly 1 correct, `text` questions must not have any choices
+      security:
+        - SiteApiToken: []
+        - UserApiToken: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateQuizQuestionRequest'
+      responses:
+        '201':
+          description: Created, returns the ID of the new question
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+  /quiz/manage:
+    get:
+      tags:
+        - Quiz
+      summary: List quiz questions for management
+      description: Lists all quiz questions including which choice is correct, requires `hosting advisor` permission
+      security:
+        - SiteApiToken: []
+        - UserApiToken: []
+      responses:
+        '200':
+          description: 'Successful query'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/QuizQuestionManageResponse'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+  /quiz/{id}:
+    delete:
+      tags:
+        - Quiz
+      summary: Delete a quiz question
+      description: Deletes a quiz question and its choices, requires `hosting advisor` permission
+      security:
+        - SiteApiToken: []
+        - UserApiToken: []
+      parameters:
+        - in: path
+          name: id
+          type: integer
+          required: true
+          description: The ID of the question to delete
+      responses:
+        '204':
+          description: Deleted
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
 

--- a/frontend/src/api/Permissions.ts
+++ b/frontend/src/api/Permissions.ts
@@ -3,6 +3,7 @@ import moment from 'moment-timezone';
 import { authHeaders, callApi, fetchArray, fetchObject } from './util';
 import { PermissionModerationLogEntry } from '../models/PermissionModerationLogEntry';
 import { UserCountPerPermission, UsersInPermission } from '../models/Permissions';
+import { HostApplication, HostApplicationDetails, SubmitAnswerData } from '../models/HostApplication';
 
 export const fetchUserCountPerPermission = (): Promise<UserCountPerPermission> =>
   fetchObject<UserCountPerPermission>({
@@ -22,6 +23,51 @@ export const fetchUsersInPermissionWithLetter = (permission: string, letter: str
 export const fetchPermissionsForUser = (username: string): Promise<string[]> =>
   fetchArray<string>({
     url: `/api/users/${encodeURIComponent(username)}/permissions`,
+  });
+
+export const fetchHostApplications = (): Promise<HostApplication[]> =>
+  fetchArray<HostApplication>({
+    url: '/api/host-applications',
+  });
+
+export const fetchHostApplicationDetails = (id: number, accessToken: string): Promise<HostApplicationDetails> =>
+  fetchObject<HostApplicationDetails>({
+    url: `/api/host-applications/${id}`,
+    config: {
+      headers: authHeaders(accessToken),
+    },
+  });
+
+export const createHostApplication = (answers: SubmitAnswerData[], accessToken: string): Promise<void> =>
+  callApi({
+    url: '/api/host-applications',
+    config: {
+      method: 'POST',
+      headers: {
+        ...authHeaders(accessToken),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ answers }),
+    },
+    status: 201,
+  });
+
+export const reviewHostApplication = (
+  id: number,
+  decision: 'approve' | 'decline',
+  accessToken: string,
+  reason?: string
+): Promise<void> =>
+  callApi({
+    url: `/api/host-applications/${id}/${decision}`,
+    config: {
+      method: 'POST',
+      headers: {
+        ...authHeaders(accessToken),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ reason }),
+    },
   });
 
 export const fetchPermissionModerationLog = (): Promise<PermissionModerationLogEntry[]> =>

--- a/frontend/src/api/Permissions.ts
+++ b/frontend/src/api/Permissions.ts
@@ -20,11 +20,6 @@ export const fetchUsersInPermissionWithLetter = (permission: string, letter: str
     url: `/api/permissions/${permission}/${letter}`,
   });
 
-export const fetchPermissionsForUser = (username: string): Promise<string[]> =>
-  fetchArray<string>({
-    url: `/api/users/${encodeURIComponent(username)}/permissions`,
-  });
-
 export const fetchHostApplications = (): Promise<HostApplication[]> =>
   fetchArray<HostApplication>({
     url: '/api/host-applications',
@@ -56,7 +51,7 @@ export const reviewHostApplication = (
   id: number,
   decision: 'approve' | 'decline',
   accessToken: string,
-  reason?: string
+  reason?: string,
 ): Promise<void> =>
   callApi({
     url: `/api/host-applications/${id}/${decision}`,

--- a/frontend/src/api/Permissions.ts
+++ b/frontend/src/api/Permissions.ts
@@ -19,6 +19,11 @@ export const fetchUsersInPermissionWithLetter = (permission: string, letter: str
     url: `/api/permissions/${permission}/${letter}`,
   });
 
+export const fetchPermissionsForUser = (username: string): Promise<string[]> =>
+  fetchArray<string>({
+    url: `/api/users/${encodeURIComponent(username)}/permissions`,
+  });
+
 export const fetchPermissionModerationLog = (): Promise<PermissionModerationLogEntry[]> =>
   fetchArray<PermissionModerationLogEntry>({
     url: `/api/permissions/log`,

--- a/frontend/src/api/Quiz.ts
+++ b/frontend/src/api/Quiz.ts
@@ -1,0 +1,39 @@
+import { CreateQuizQuestionData, ManageQuizQuestion, QuizQuestion } from '../models/QuizQuestion';
+import { authHeaders, callApi, fetchArray, fetchObject } from './util';
+
+export const fetchQuizQuestions = (): Promise<QuizQuestion[]> =>
+  fetchArray<QuizQuestion>({
+    url: '/api/quiz',
+  });
+
+export const fetchQuizQuestionsForManagement = (accessToken: string): Promise<ManageQuizQuestion[]> =>
+  fetchArray<ManageQuizQuestion>({
+    url: '/api/quiz/manage',
+    config: {
+      headers: authHeaders(accessToken),
+    },
+  });
+
+export const createQuizQuestion = (data: CreateQuizQuestionData, accessToken: string): Promise<{ id: number }> =>
+  fetchObject<{ id: number }>({
+    url: '/api/quiz',
+    config: {
+      method: 'POST',
+      headers: {
+        ...authHeaders(accessToken),
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    },
+    status: 201,
+  });
+
+export const deleteQuizQuestion = (id: number, accessToken: string): Promise<void> =>
+  callApi({
+    url: `/api/quiz/${id}`,
+    config: {
+      method: 'DELETE',
+      headers: authHeaders(accessToken),
+    },
+    status: 204,
+  });

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -6,6 +6,7 @@ import * as UBL from './UBL';
 import * as ServerTime from './ServerTime';
 import * as Alerts from './Alerts';
 import * as Errors from './Errors';
+import * as Quiz from './Quiz';
 
 export const MatchesApi = Matches;
 export const AuthenticationApi = Authentication;
@@ -15,3 +16,4 @@ export const UBLApi = UBL;
 export const ServerTimeApi = ServerTime;
 export const AlertsApi = Alerts;
 export const ApiErrors = Errors;
+export const QuizApi = Quiz;

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -26,6 +26,9 @@ import Helmet from 'react-helmet';
 import { CreateBanPage } from './ubl/CreateBanPage';
 import { CurrentUblPage, UuidHistoryPage } from './ubl';
 import { ModifiersPage } from '../modifiers/components/ModifiersPage';
+import { HostApplicationsPage } from './host-applications';
+import { ApplyHostApplicationPage } from './host-applications/ApplyHostApplication';
+import { QuizManagementPage } from './quiz';
 
 reactGa.initialize('UA-71696797-2');
 
@@ -88,6 +91,8 @@ class RoutesComponent extends React.PureComponent<RouteComponentProps<any>> {
         <Route path="/m/:id" component={MatchDetailsPage} />
         <Route path="/matches/:host" component={HistoryPage} />
         <Route path="/matches" component={UpcomingMatchesPage} />
+        <Route path="/host-applications/apply" component={ApplyHostApplicationPage} />
+        <Route path="/host-applications" component={HostApplicationsPage} />
         <Route path="/members" component={MembersPage} />
         <Route path="/login" component={LoginPage} />
         <AuthenticatedRoute path="/profile" component={ProfilePage} permission={[]} {...this.props} />
@@ -101,6 +106,7 @@ class RoutesComponent extends React.PureComponent<RouteComponentProps<any>> {
           {...this.props}
         />
         <AuthenticatedRoute path="/modifiers" component={ModifiersPage} permission="hosting advisor" {...this.props} />
+        <AuthenticatedRoute path="/quiz" component={QuizManagementPage} permission="hosting advisor" {...this.props} />
         <Route path="/" exact component={HomePage} />
         <Route component={NotFoundPage} />
       </Switch>

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -53,6 +53,7 @@ const NavbarComponent: React.FunctionComponent<StateProps & DispatchProps> = ({ 
     <NavbarGroup>
       <NavbarButton to="/host" text="Host" icon="cloud-upload" />
       <NavbarButton to="/matches" text="Matches" icon="numbered-list" />
+      <NavbarButton to="/host-applications" text="Host Applications" icon="inbox" />
       <NavbarButton to="/members" text="Members" icon="user" />
       {/*<NavbarButton to="/ubl" text="Ban List" icon="take-action" />*/}
       <WithPermission permission="hosting advisor">
@@ -60,6 +61,9 @@ const NavbarComponent: React.FunctionComponent<StateProps & DispatchProps> = ({ 
       </WithPermission>
       <WithPermission permission="hosting advisor">
         <NavbarButton text="Modifiers" icon="unresolve" to="/modifiers" />
+      </WithPermission>
+      <WithPermission permission="hosting advisor">
+        <NavbarButton to="/quiz" text="Application Quiz" icon="help" />
       </WithPermission>
     </NavbarGroup>
     <NavbarGroup>

--- a/frontend/src/components/host-applications/ApplyHostApplication.tsx
+++ b/frontend/src/components/host-applications/ApplyHostApplication.tsx
@@ -1,0 +1,144 @@
+import * as React from 'react';
+import { Button, Callout, H1, Intent, NonIdealState, Spinner } from '@blueprintjs/core';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router';
+import { createSelector } from 'reselect';
+import { ApplicationState } from '../../state/ApplicationState';
+import { getAccessToken, getPermissions, getUsername } from '../../state/Selectors';
+import { ApiErrors, PermissionsApi, QuizApi } from '../../api';
+import { QuizQuestion } from '../../models/QuizQuestion';
+import { SubmitAnswerData } from '../../models/HostApplication';
+import { HostApplicationForm } from './HostApplicationForm';
+
+type StateProps = {
+  readonly accessToken: string | null;
+  readonly username: string | null;
+  readonly permissions: string[];
+};
+
+type State = {
+  readonly questions: QuizQuestion[];
+  readonly loading: boolean;
+  readonly submitting: boolean;
+  readonly submitted: boolean;
+  readonly error: string | null;
+};
+
+class ApplyHostApplicationPageComponent extends React.PureComponent<StateProps & RouteComponentProps<any>, State> {
+  state: State = {
+    questions: [],
+    loading: true,
+    submitting: false,
+    submitted: false,
+    error: null,
+  };
+
+  public componentDidMount() {
+    this.load();
+  }
+
+  private canApply = () =>
+    !!this.props.username && !this.props.permissions.includes('host') && !this.props.permissions.includes('trial host') && !this.props.permissions.includes('hosting banned');
+
+  private isBanned = () => this.props.permissions.includes('hosting banned');
+
+  private load = async () => {
+    try {
+      const questions = await QuizApi.fetchQuizQuestions();
+      this.setState({ questions, loading: false, error: null });
+    } catch (e) {
+      this.setState({ loading: false, error: 'Unable to load quiz questions' });
+    }
+  };
+
+  private submit = async (answers: SubmitAnswerData[]) => {
+    if (!this.props.accessToken) return;
+
+    this.setState({ submitting: true, error: null });
+    try {
+      await PermissionsApi.createHostApplication(answers, this.props.accessToken);
+      this.setState({ submitting: false, submitted: true });
+    } catch (error) {
+      const message =
+        error instanceof ApiErrors.BadDataError ? error.message.replace(/^User supplied invalid data: /, '') : 'Unable to submit host application';
+      this.setState({ submitting: false, error: message });
+    }
+  };
+
+  public render() {
+    if (this.isBanned()) {
+      return (
+        <NonIdealState
+          icon="ban-circle"
+          title="You cannot apply"
+          description="You are banned from hosting and cannot submit an application."
+          action={
+            <Link to="/host-applications">
+              <Button>Back to Host Applications</Button>
+            </Link>
+          }
+        />
+      );
+    }
+
+    if (!this.canApply()) {
+      return (
+        <NonIdealState
+          icon="tick-circle"
+          title="You don't need to apply"
+          description="You're already a host, or you're not logged in."
+          action={
+            <Link to="/host-applications">
+              <Button>Back to Host Applications</Button>
+            </Link>
+          }
+        />
+      );
+    }
+
+    if (this.state.submitted) {
+      return (
+        <NonIdealState
+          icon="tick"
+          title="Application submitted"
+          description="Head back to Host Applications to check on its status."
+          action={
+            <Link to="/host-applications">
+              <Button intent={Intent.PRIMARY}>Back to Host Applications</Button>
+            </Link>
+          }
+        />
+      );
+    }
+
+    return (
+      <div>
+        <H1>Apply to Host</H1>
+
+        {this.state.error && <Callout intent={Intent.DANGER}>{this.state.error}</Callout>}
+
+        {this.state.loading ? (
+          <Spinner />
+        ) : this.state.questions.length === 0 ? (
+          <NonIdealState icon="help" title="No quiz questions have been configured yet" />
+        ) : (
+          <HostApplicationForm questions={this.state.questions} submitting={this.state.submitting} onSubmit={this.submit} />
+        )}
+      </div>
+    );
+  }
+}
+
+const stateSelector = createSelector<ApplicationState, string | null, string | null, string[], StateProps>(
+  getAccessToken,
+  getUsername,
+  getPermissions,
+  (accessToken, username, permissions) => ({ accessToken, username, permissions }),
+);
+
+export const ApplyHostApplicationPage: React.ComponentType<RouteComponentProps<any>> = connect<
+  StateProps,
+  {},
+  RouteComponentProps<any>
+>(stateSelector)(ApplyHostApplicationPageComponent);

--- a/frontend/src/components/host-applications/ExistingHostApplication.tsx
+++ b/frontend/src/components/host-applications/ExistingHostApplication.tsx
@@ -1,0 +1,181 @@
+import * as React from 'react';
+import moment from 'moment-timezone';
+import { Button, Classes, Dialog, H4, Intent, Spinner, Tag, TextArea } from '@blueprintjs/core';
+import { HostApplication, HostApplicationDetails } from '../../models/HostApplication';
+import { ApiErrors, PermissionsApi } from '../../api';
+
+type Props = {
+  readonly application: HostApplication;
+  readonly canReview: boolean;
+  readonly isOwn: boolean;
+  readonly accessToken: string;
+  readonly onReviewed: () => void;
+};
+
+type State = {
+  readonly expanded: boolean;
+  readonly loadingDetails: boolean;
+  readonly details: HostApplicationDetails | null;
+  readonly error: string | null;
+  readonly reviewing: boolean;
+  readonly declineDialogOpen: boolean;
+  readonly declineReason: string;
+};
+
+const statusIntent = (status: HostApplication['status']): Intent => {
+  if (status === 'approved') return Intent.SUCCESS;
+  if (status === 'declined') return Intent.DANGER;
+  return Intent.WARNING;
+};
+
+export class ExistingHostApplication extends React.PureComponent<Props, State> {
+  state: State = {
+    expanded: false,
+    loadingDetails: false,
+    details: null,
+    error: null,
+    reviewing: false,
+    declineDialogOpen: false,
+    declineReason: '',
+  };
+
+  private toggleExpanded = () => {
+    if (this.state.expanded) {
+      this.setState({ expanded: false });
+      return;
+    }
+
+    this.setState({ expanded: true, loadingDetails: true, error: null });
+    PermissionsApi.fetchHostApplicationDetails(this.props.application.id, this.props.accessToken)
+      .then(details => this.setState({ details, loadingDetails: false }))
+      .catch(() => this.setState({ loadingDetails: false, error: 'Unable to load application details' }));
+  };
+
+  private review = (decision: 'approve' | 'decline', reason?: string) => {
+    this.setState({ reviewing: true });
+    PermissionsApi.reviewHostApplication(this.props.application.id, decision, this.props.accessToken, reason)
+      .then(() => {
+        this.setState({ reviewing: false, declineDialogOpen: false, declineReason: '' });
+        this.props.onReviewed();
+      })
+      .catch(error => {
+        const message =
+          error instanceof ApiErrors.BadDataError
+            ? error.message.replace(/^User supplied invalid data: /, '')
+            : `Unable to ${decision} application`;
+        this.setState({ reviewing: false, error: message });
+      });
+  };
+
+  private openDeclineDialog = () => this.setState({ declineDialogOpen: true, declineReason: '' });
+
+  private closeDeclineDialog = () => this.setState({ declineDialogOpen: false });
+
+  private onDeclineReasonChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const declineReason = e.target.value;
+    this.setState({ declineReason });
+  };
+
+  private confirmDecline = () => this.review('decline', this.state.declineReason);
+
+  render() {
+    const { application, canReview, isOwn } = this.props;
+    const { expanded, loadingDetails, details, error, reviewing, declineDialogOpen, declineReason } = this.state;
+
+    return (
+      <div
+        className={`${Classes.CARD} ${Classes.ELEVATION_1}`}
+        style={isOwn ? { marginBottom: 15, borderLeft: '4px solid #2B95D6' } : { marginBottom: 15 }}
+      >
+        <H4>
+          /u/{application.username} <Tag intent={statusIntent(application.status)}>{application.status}</Tag>{' '}
+          {isOwn && <Tag intent={Intent.PRIMARY}>Your application</Tag>}
+        </H4>
+        <small>{moment.utc(application.created).format('MMM Do YYYY, HH:mm z')}</small>
+        {application.reviewedBy && (
+          <p>
+            Reviewed by /u/{application.reviewedBy}
+            {application.reviewedAt && ` on ${moment.utc(application.reviewedAt).format('MMM Do YYYY, HH:mm z')}`}
+          </p>
+        )}
+        {application.status === 'declined' && application.reviewReason && (
+          <p>
+            <strong>Reason:</strong> {application.reviewReason}
+          </p>
+        )}
+
+        <div style={{ marginTop: 10 }}>
+          <Button minimal icon={expanded ? 'chevron-up' : 'chevron-down'} onClick={this.toggleExpanded}>
+            {expanded ? 'Hide answers' : 'View answers'}
+          </Button>
+        </div>
+
+        {expanded && loadingDetails && <Spinner size={20} />}
+        {expanded && error && <p className={Classes.TEXT_MUTED}>{error}</p>}
+        {expanded && details && (
+          <div style={{ marginTop: 10 }}>
+            {details.answers.map((answer, index) => (
+              <div key={index} style={{ marginBottom: 10 }}>
+                <strong>{answer.questionPrompt}</strong>
+                <p>
+                  {answer.questionType === 'multiple choice' ? (
+                    <>
+                      {answer.choiceText}
+                      {canReview && answer.choiceCorrect !== null && (
+                        <>
+                          {' '}
+                          <Tag intent={answer.choiceCorrect ? Intent.SUCCESS : Intent.DANGER}>
+                            {answer.choiceCorrect ? 'correct' : 'incorrect'}
+                          </Tag>
+                        </>
+                      )}
+                    </>
+                  ) : (
+                    answer.textAnswer
+                  )}
+                </p>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {canReview && application.status === 'pending' && (
+          <div style={{ marginTop: 10, display: 'flex', gap: 10 }}>
+            <Button intent={Intent.SUCCESS} icon="tick" loading={reviewing} onClick={() => this.review('approve')}>
+              Approve
+            </Button>
+            <Button intent={Intent.DANGER} icon="cross" loading={reviewing} onClick={this.openDeclineDialog}>
+              Decline
+            </Button>
+          </div>
+        )}
+
+        <Dialog isOpen={declineDialogOpen} title="Decline application" onClose={this.closeDeclineDialog}>
+          <div className={Classes.DIALOG_BODY}>
+            <p>Please provide a reason for declining this application. This will be visible to the applicant.</p>
+            <TextArea
+              fill
+              growVertically
+              value={declineReason}
+              onChange={this.onDeclineReasonChange}
+              placeholder="Reason for declining"
+            />
+          </div>
+          <div className={Classes.DIALOG_FOOTER}>
+            <div className={Classes.DIALOG_FOOTER_ACTIONS}>
+              <Button onClick={this.closeDeclineDialog}>Cancel</Button>
+              <Button
+                intent={Intent.DANGER}
+                loading={reviewing}
+                disabled={declineReason.trim().length === 0}
+                onClick={this.confirmDecline}
+              >
+                Decline
+              </Button>
+            </div>
+          </div>
+        </Dialog>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/host-applications/HostApplicationForm.tsx
+++ b/frontend/src/components/host-applications/HostApplicationForm.tsx
@@ -1,0 +1,102 @@
+import * as React from 'react';
+import { Button, Classes, H5, Intent, Radio, RadioGroup, TextArea } from '@blueprintjs/core';
+import { QuizQuestion } from '../../models/QuizQuestion';
+import { SubmitAnswerData } from '../../models/HostApplication';
+
+type Props = {
+  readonly questions: QuizQuestion[];
+  readonly submitting: boolean;
+  readonly onSubmit: (answers: SubmitAnswerData[]) => void;
+};
+
+type AnswerState = {
+  readonly choiceId?: number;
+  readonly textAnswer?: string;
+};
+
+type State = {
+  readonly answers: { [questionId: number]: AnswerState };
+};
+
+export class HostApplicationForm extends React.PureComponent<Props, State> {
+  state: State = {
+    answers: {},
+  };
+
+  private onChoiceChange = (questionId: number) => (e: React.FormEvent<HTMLInputElement>) => {
+    const choiceId = Number(e.currentTarget.value);
+    this.setState(prev => ({
+      answers: { ...prev.answers, [questionId]: { choiceId } },
+    }));
+  };
+
+  private onTextChange = (questionId: number) => (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const textAnswer = e.target.value;
+    this.setState(prev => ({
+      answers: { ...prev.answers, [questionId]: { textAnswer } },
+    }));
+  };
+
+  private isComplete = (): boolean =>
+    this.props.questions.every(question => {
+      const answer = this.state.answers[question.id];
+      if (!answer) return false;
+
+      return question.questionType === 'multiple choice'
+        ? answer.choiceId !== undefined
+        : !!answer.textAnswer && answer.textAnswer.trim().length > 0;
+    });
+
+  private submit = () => {
+    const answers: SubmitAnswerData[] = this.props.questions.map(question => ({
+      questionId: question.id,
+      choiceId: this.state.answers[question.id] && this.state.answers[question.id].choiceId,
+      textAnswer: this.state.answers[question.id] && this.state.answers[question.id].textAnswer,
+    }));
+
+    this.props.onSubmit(answers);
+  };
+
+  render() {
+    const { questions, submitting } = this.props;
+
+    return (
+      <div>
+        {questions.map(question => (
+          <div key={question.id} style={{ marginBottom: 20 }}>
+            <H5>{question.prompt}</H5>
+
+            {question.questionType === 'multiple choice' ? (
+              <RadioGroup
+                onChange={this.onChoiceChange(question.id)}
+                selectedValue={this.state.answers[question.id] && this.state.answers[question.id].choiceId}
+              >
+                {question.choices.map(choice => (
+                  <Radio key={choice.id} label={choice.text} value={choice.id} disabled={submitting} />
+                ))}
+              </RadioGroup>
+            ) : (
+              <TextArea
+                className={Classes.FILL}
+                fill
+                value={(this.state.answers[question.id] && this.state.answers[question.id].textAnswer) || ''}
+                onChange={this.onTextChange(question.id)}
+                disabled={submitting}
+              />
+            )}
+          </div>
+        ))}
+
+        <Button
+          type="button"
+          intent={Intent.PRIMARY}
+          icon="add"
+          disabled={submitting || !this.isComplete()}
+          onClick={this.submit}
+        >
+          Submit Application
+        </Button>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/host-applications/index.tsx
+++ b/frontend/src/components/host-applications/index.tsx
@@ -1,0 +1,117 @@
+import * as React from 'react';
+import { Button, Callout, H1, Intent, NonIdealState, Spinner } from '@blueprintjs/core';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { RouteComponentProps } from 'react-router';
+import { createSelector } from 'reselect';
+import { ApplicationState } from '../../state/ApplicationState';
+import { getAccessToken, getPermissions, getUsername } from '../../state/Selectors';
+import { PermissionsApi } from '../../api';
+import { HostApplication } from '../../models/HostApplication';
+import { ExistingHostApplication } from './ExistingHostApplication';
+
+type StateProps = {
+  readonly accessToken: string | null;
+  readonly username: string | null;
+  readonly permissions: string[];
+};
+
+type State = {
+  readonly applications: HostApplication[];
+  readonly loading: boolean;
+  readonly error: string | null;
+};
+
+class HostApplicationsPageComponent extends React.PureComponent<StateProps & RouteComponentProps<any>, State> {
+  state: State = {
+    applications: [],
+    loading: true,
+    error: null,
+  };
+
+  public componentDidMount() {
+    this.loadApplications();
+  }
+
+  private canApply = () =>
+    !!this.props.username && !this.props.permissions.includes('host') && !this.props.permissions.includes('trial host') && !this.props.permissions.includes('hosting banned');
+
+  private isBanned = () => this.props.permissions.includes('hosting banned');
+
+  private canReview = () => this.props.permissions.includes('hosting advisor');
+
+  private sortedApplications = (): HostApplication[] => {
+    const { username } = this.props;
+    if (!username) return this.state.applications;
+
+    const mine = this.state.applications.filter(application => application.username === username);
+    const others = this.state.applications.filter(application => application.username !== username);
+    return [...mine, ...others];
+  };
+
+  private loadApplications = async () => {
+    try {
+      const applications = await PermissionsApi.fetchHostApplications();
+      this.setState({ applications, loading: false, error: null });
+    } catch (error) {
+      this.setState({ loading: false, error: 'Unable to load host applications' });
+    }
+  };
+
+  public render() {
+    const canApply = this.canApply();
+    const canReview = this.canReview();
+
+    return (
+      <div>
+        <H1>Host Applications</H1>
+
+        {this.state.error && <Callout intent={Intent.DANGER}>{this.state.error}</Callout>}
+
+        {this.isBanned() && (
+          <Callout intent={Intent.DANGER} style={{ marginBottom: 20 }}>
+            You are banned from hosting and cannot submit an application.
+          </Callout>
+        )}
+
+        {canApply && (
+          <div style={{ marginBottom: 20 }}>
+            <Link to="/host-applications/apply">
+              <Button intent={Intent.PRIMARY} icon="add">
+                Apply to host
+              </Button>
+            </Link>
+          </div>
+        )}
+
+        {this.state.loading ? (
+          <Spinner />
+        ) : this.state.applications.length === 0 ? (
+          <NonIdealState icon="inbox" title="No host applications yet" description="There are no host applications to see yet." />
+        ) : (
+          this.sortedApplications().map(application => (
+            <ExistingHostApplication
+              application={application}
+              key={application.id}
+              canReview={canReview}
+              isOwn={application.username === this.props.username}
+              accessToken={this.props.accessToken || ''}
+              onReviewed={this.loadApplications}
+            />
+          ))
+        )}
+      </div>
+    );
+  }
+}
+
+const stateSelector = createSelector<ApplicationState, string | null, string | null, string[], StateProps>(
+  getAccessToken,
+  getUsername,
+  getPermissions,
+  (accessToken, username, permissions) => ({ accessToken, username, permissions }),
+);
+
+export const HostApplicationsPage: React.ComponentType<RouteComponentProps<any>> = connect<StateProps, {}, RouteComponentProps<any>>(
+  stateSelector,
+)(HostApplicationsPageComponent);

--- a/frontend/src/components/host-status/index.tsx
+++ b/frontend/src/components/host-status/index.tsx
@@ -1,40 +1,12 @@
 import * as React from 'react';
 import { Classes, Icon, Intent, Tag } from '@blueprintjs/core';
-import { fetchPermissionsForUser } from '../../api/Permissions';
-
-const permissionRequests = new Map<string, Promise<string[]>>();
-
-const permissionsFor = (username: string): Promise<string[]> => {
-  const existing = permissionRequests.get(username);
-  if (existing) return existing;
-
-  const request = fetchPermissionsForUser(username).catch(() => []);
-  permissionRequests.set(username, request);
-  return request;
-};
 
 type HostStatusProps = {
-  readonly username: string;
+  readonly roles: Array<string>;
 };
 
-export const HostStatus: React.FunctionComponent<HostStatusProps> = ({ username }) => {
-  const [permissions, setPermissions] = React.useState<string[] | null>(null);
-
-  React.useEffect(() => {
-    let mounted = true;
-
-    permissionsFor(username).then(result => {
-      if (mounted) setPermissions(result);
-    });
-
-    return () => {
-      mounted = false;
-    };
-  }, [username]);
-
-  if (!permissions) return null;
-
-  if (permissions.indexOf('host') !== -1) {
+export const HostStatus: React.FunctionComponent<HostStatusProps> = ({ roles }) => {
+  if (roles.indexOf('host') !== -1) {
     return (
       <Tag intent={Intent.SUCCESS} className={`${Classes.LARGE}`} title="Verified Host">
         <Icon icon="tick-circle" /> Verified Host
@@ -42,7 +14,7 @@ export const HostStatus: React.FunctionComponent<HostStatusProps> = ({ username 
     );
   }
 
-  if (permissions.indexOf('trial host') !== -1) {
+  if (roles.indexOf('trial host') !== -1) {
     return (
       <Tag intent={Intent.WARNING} className={`${Classes.LARGE}`} title="Trial Host">
         <Icon icon="person" /> Trial Host

--- a/frontend/src/components/host-status/index.tsx
+++ b/frontend/src/components/host-status/index.tsx
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import { Classes, Icon, Intent, Tag } from '@blueprintjs/core';
+import { fetchPermissionsForUser } from '../../api/Permissions';
+
+const permissionRequests = new Map<string, Promise<string[]>>();
+
+const permissionsFor = (username: string): Promise<string[]> => {
+  const existing = permissionRequests.get(username);
+  if (existing) return existing;
+
+  const request = fetchPermissionsForUser(username).catch(() => []);
+  permissionRequests.set(username, request);
+  return request;
+};
+
+type HostStatusProps = {
+  readonly username: string;
+};
+
+export const HostStatus: React.FunctionComponent<HostStatusProps> = ({ username }) => {
+  const [permissions, setPermissions] = React.useState<string[] | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+
+    permissionsFor(username).then(result => {
+      if (mounted) setPermissions(result);
+    });
+
+    return () => {
+      mounted = false;
+    };
+  }, [username]);
+
+  if (!permissions) return null;
+
+  if (permissions.indexOf('host') !== -1) {
+    return (
+      <Tag intent={Intent.SUCCESS} className={`${Classes.LARGE}`} title="Verified Host">
+        <Icon icon="tick-circle" /> Verified Host
+      </Tag>
+    );
+  }
+
+  if (permissions.indexOf('trial host') !== -1) {
+    return (
+      <Tag intent={Intent.WARNING} className={`${Classes.LARGE}`} title="Trial Host">
+        <Icon icon="person" /> Trial Host
+      </Tag>
+    );
+  }
+
+  return null;
+};

--- a/frontend/src/components/host/CreateMatchForm.tsx
+++ b/frontend/src/components/host/CreateMatchForm.tsx
@@ -36,6 +36,7 @@ export type CreateMatchFormProps = {
   readonly is12h: boolean;
   readonly changeTemplate: (newTemplate: string) => void;
   readonly createMatch: (data: CreateMatchData) => Promise<void>;
+  readonly roles: Array<string>;
 };
 
 const stopEnterSubmit: React.KeyboardEventHandler<any> = (e: React.KeyboardEvent<any>): void => {
@@ -140,6 +141,7 @@ class CreateMatchFormComponent extends React.PureComponent<
       createMatch,
       error,
       asyncValidating,
+      roles,
     } = this.props;
 
     const disabledAsync = submitting || asyncValidating !== false; // asyncvalidating is string | boolean
@@ -157,6 +159,7 @@ class CreateMatchFormComponent extends React.PureComponent<
       approvedBy: null,
       created: moment.utc(),
       version: currentValues.version || currentValues.mainVersion,
+      roles,
     };
 
     return (

--- a/frontend/src/components/host/index.tsx
+++ b/frontend/src/components/host/index.tsx
@@ -9,7 +9,7 @@ import { renderTeamStyle, TeamStyles } from '../../models/TeamStyles';
 import { MatchesApi, ApiErrors } from '../../api';
 import { change, getFormValues, SubmissionError } from 'redux-form';
 import { renderToMarkdown } from './TemplateField';
-import { getAccessToken, getUsername, isDarkMode, is12hFormat } from '../../state/Selectors';
+import { getAccessToken, getUsername, isDarkMode, is12hFormat, getPermissions } from '../../state/Selectors';
 import { createSelector, Selector } from 'reselect';
 import { CreateMatchData } from '../../models/CreateMatchData';
 import { SetSavedHostFormData } from '../../actions';
@@ -17,6 +17,7 @@ import { SetSavedHostFormData } from '../../actions';
 export type HostingPageStateProps = {
   readonly formValues: CreateMatchData | undefined;
   readonly username: string;
+  readonly roles: Array<string>;
   readonly accessToken: string;
   readonly is12h: boolean;
   readonly savedData: CreateMatchData;
@@ -122,6 +123,7 @@ class HostingPageComponent extends React.PureComponent<
         changeTemplate={this.props.changeTemplate}
         createMatch={this.handleCreateMatch}
         is12h={this.props.is12h}
+        roles={this.props.roles}
       />
     );
   }
@@ -130,6 +132,7 @@ class HostingPageComponent extends React.PureComponent<
 const stateSelector = createSelector<
   ApplicationState,
   string | null,
+  Array<string>,
   CreateMatchData,
   string | null,
   boolean,
@@ -138,16 +141,18 @@ const stateSelector = createSelector<
   HostingPageStateProps
 >(
   getUsername,
+  getPermissions,
   valuesSelector,
   getAccessToken,
   isDarkMode,
   is12hFormat,
   state => state.hostFormSavedData,
-  (username, formValues, accessToken, isDarkMode, is12h, savedData) => ({
+  (username, permissions, formValues, accessToken, isDarkMode, is12h, savedData) => ({
     formValues,
     is12h,
     savedData,
     username: username || 'ERROR NO USERNAME IN STORE',
+    roles: permissions,
     accessToken: accessToken || 'ERROR NO ACCESS TOKEN IN STORE',
   }),
 );

--- a/frontend/src/components/match-details/index.tsx
+++ b/frontend/src/components/match-details/index.tsx
@@ -15,6 +15,7 @@ import { ApproveMatch, FetchMatchDetails, RemoveMatch } from '../../actions';
 import { getUsername, matchesPermissions } from '../../state/Selectors';
 import { RemovedTag } from './RemovedTag';
 import { RemovedInfo } from './RemovedInfo';
+import { HostStatus } from '../host-status';
 
 type StateProps = {
   readonly details: MatchDetailsState;
@@ -109,6 +110,7 @@ class MatchDetailsComponent extends React.PureComponent<StateProps & DispatchPro
             <Tag intent={Intent.SUCCESS} title="Region - Location" className={`${Classes.LARGE}`}>
               <Icon icon="globe" /> {region} - {location}
             </Tag>
+            <HostStatus username={author} />
             {tournament && (
               <Tag intent={Intent.PRIMARY} className={`${Classes.LARGE}`}>
                 <Icon icon="timeline-bar-chart" /> Tournament

--- a/frontend/src/components/match-details/index.tsx
+++ b/frontend/src/components/match-details/index.tsx
@@ -98,6 +98,7 @@ class MatchDetailsComponent extends React.PureComponent<StateProps & DispatchPro
       removedReason,
       approvedBy,
       mainVersion,
+      roles,
     } = this.props.details.match;
 
     const { canApprove, canRemove, approve, remove } = this.props;
@@ -110,7 +111,7 @@ class MatchDetailsComponent extends React.PureComponent<StateProps & DispatchPro
             <Tag intent={Intent.SUCCESS} title="Region - Location" className={`${Classes.LARGE}`}>
               <Icon icon="globe" /> {region} - {location}
             </Tag>
-            <HostStatus username={author} />
+            <HostStatus roles={roles} />
             {tournament && (
               <Tag intent={Intent.PRIMARY} className={`${Classes.LARGE}`}>
                 <Icon icon="timeline-bar-chart" /> Tournament

--- a/frontend/src/components/match-row/index.tsx
+++ b/frontend/src/components/match-row/index.tsx
@@ -16,6 +16,7 @@ import { ApplicationState } from '../../state/ApplicationState';
 import { getUsername, matchesPermissions } from '../../state/Selectors';
 import { ApproveMatch, RemoveMatch } from '../../actions';
 import { ServerTag } from './ServerTag';
+import { HostStatus } from '../host-status';
 
 type MatchRowProps = {
   readonly match: Match;
@@ -76,6 +77,7 @@ class MatchRowComponent extends React.PureComponent<MatchRowProps & StateProps &
           )}
         </div>
         <div className="match-top-right-ribbon">
+          <HostStatus username={match.author} />
           <TagList intent={Intent.PRIMARY} title="Tag" items={match.tags} icon="tag" />
           {match.tournament && (
             <Tag intent={Intent.PRIMARY} className={`${Classes.LARGE}`}>

--- a/frontend/src/components/match-row/index.tsx
+++ b/frontend/src/components/match-row/index.tsx
@@ -77,7 +77,7 @@ class MatchRowComponent extends React.PureComponent<MatchRowProps & StateProps &
           )}
         </div>
         <div className="match-top-right-ribbon">
-          <HostStatus username={match.author} />
+          <HostStatus roles={match.roles} />
           <TagList intent={Intent.PRIMARY} title="Tag" items={match.tags} icon="tag" />
           {match.tournament && (
             <Tag intent={Intent.PRIMARY} className={`${Classes.LARGE}`}>

--- a/frontend/src/components/quiz/CreateQuizQuestionForm.tsx
+++ b/frontend/src/components/quiz/CreateQuizQuestionForm.tsx
@@ -1,0 +1,152 @@
+import * as React from 'react';
+import { Button, Classes, HTMLSelect, InputGroup, Intent, Radio, RadioGroup } from '@blueprintjs/core';
+import { CreateQuizQuestionData, QuestionType } from '../../models/QuizQuestion';
+
+type Props = {
+  readonly onSubmit: (question: CreateQuizQuestionData) => Promise<boolean>;
+};
+
+type ChoiceDraft = {
+  readonly text: string;
+};
+
+type State = {
+  readonly prompt: string;
+  readonly questionType: QuestionType;
+  readonly choices: ChoiceDraft[];
+  readonly correctIndex: number;
+  readonly submitting: boolean;
+};
+
+const emptyChoices: ChoiceDraft[] = [{ text: '' }, { text: '' }];
+
+export class CreateQuizQuestionForm extends React.PureComponent<Props, State> {
+  state: State = {
+    prompt: '',
+    questionType: 'multiple choice',
+    choices: emptyChoices,
+    correctIndex: 0,
+    submitting: false,
+  };
+
+  private reset = () =>
+    this.setState({
+      prompt: '',
+      questionType: 'multiple choice',
+      choices: emptyChoices,
+      correctIndex: 0,
+      submitting: false,
+    });
+
+  private onPromptChange = (e: React.ChangeEvent<HTMLInputElement>) => this.setState({ prompt: e.target.value });
+
+  private onTypeChange = (e: React.ChangeEvent<HTMLSelectElement>) =>
+    this.setState({ questionType: e.target.value as QuestionType });
+
+  private onChoiceTextChange = (index: number) => (e: React.ChangeEvent<HTMLInputElement>) => {
+    const text = e.target.value;
+    this.setState(prev => ({
+      choices: prev.choices.map((choice, i) => (i === index ? { text } : choice)),
+    }));
+  };
+
+  private onCorrectChange = (index: number) => () => this.setState({ correctIndex: index });
+
+  private addChoice = () => this.setState(prev => ({ choices: [...prev.choices, { text: '' }] }));
+
+  private removeChoice = (index: number) => () =>
+    this.setState(prev => ({
+      choices: prev.choices.filter((_, i) => i !== index),
+      correctIndex: prev.correctIndex >= index && prev.correctIndex > 0 ? prev.correctIndex - 1 : prev.correctIndex,
+    }));
+
+  private isValid = (): boolean => {
+    if (!this.state.prompt.trim()) return false;
+
+    if (this.state.questionType === 'multiple choice') {
+      const filled = this.state.choices.filter(c => c.text.trim().length > 0);
+      return filled.length >= 2 && this.state.choices.every(c => c.text.trim().length > 0);
+    }
+
+    return true;
+  };
+
+  private submit = () => {
+    const data: CreateQuizQuestionData =
+      this.state.questionType === 'multiple choice'
+        ? {
+            prompt: this.state.prompt.trim(),
+            questionType: 'multiple choice',
+            choices: this.state.choices.map((choice, index) => ({
+              text: choice.text.trim(),
+              correct: index === this.state.correctIndex,
+            })),
+          }
+        : {
+            prompt: this.state.prompt.trim(),
+            questionType: 'text',
+            choices: [],
+          };
+
+    this.setState({ submitting: true });
+    this.props.onSubmit(data).then(reset => {
+      if (reset) this.reset();
+      else this.setState({ submitting: false });
+    });
+  };
+
+  render() {
+    const { prompt, questionType, choices, correctIndex, submitting } = this.state;
+
+    return (
+      <div>
+        <InputGroup
+          className={Classes.LARGE}
+          placeholder="Question prompt"
+          value={prompt}
+          onChange={this.onPromptChange}
+          disabled={submitting}
+        />
+
+        <div style={{ marginTop: 10 }}>
+          <HTMLSelect value={questionType} onChange={this.onTypeChange} disabled={submitting}>
+            <option value="multiple choice">Multiple choice</option>
+            <option value="text">Text answer</option>
+          </HTMLSelect>
+        </div>
+
+        {questionType === 'multiple choice' && (
+          <RadioGroup label="Choices (select the correct answer)" onChange={() => undefined} selectedValue={correctIndex}>
+            {choices.map((choice, index) => (
+              <div key={index} style={{ display: 'flex', alignItems: 'center', marginBottom: 8 }}>
+                <Radio value={index} checked={index === correctIndex} onChange={this.onCorrectChange(index)} style={{ marginBottom: 0, marginRight: 10 }} />
+                <InputGroup
+                  placeholder={`Choice ${index + 1}`}
+                  value={choice.text}
+                  onChange={this.onChoiceTextChange(index)}
+                  disabled={submitting}
+                  style={{ flex: 1 }}
+                />
+                {choices.length > 2 && (
+                  <Button icon="trash" minimal onClick={this.removeChoice(index)} disabled={submitting} style={{ marginLeft: 5 }} />
+                )}
+              </div>
+            ))}
+          </RadioGroup>
+        )}
+
+        {questionType === 'multiple choice' && (
+          <Button icon="add" minimal onClick={this.addChoice} disabled={submitting}>
+            Add choice
+          </Button>
+        )}
+
+        <div style={{ marginTop: 10 }}>
+          <Button intent={Intent.PRIMARY} icon="add" disabled={submitting || !this.isValid()} onClick={this.submit}>
+            Create question
+          </Button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/quiz/ExistingQuizQuestion.tsx
+++ b/frontend/src/components/quiz/ExistingQuizQuestion.tsx
@@ -1,0 +1,63 @@
+import * as React from 'react';
+import { Alert, Button, Classes, Intent, Tag } from '@blueprintjs/core';
+import { ManageQuizQuestion } from '../../models/QuizQuestion';
+
+type Props = {
+  readonly question: ManageQuizQuestion;
+  readonly onDelete: (id: number) => void;
+};
+
+type State = {
+  readonly isAlertOpen: boolean;
+};
+
+export class ExistingQuizQuestion extends React.PureComponent<Props, State> {
+  state: State = {
+    isAlertOpen: false,
+  };
+
+  private onClick = () => this.setState({ isAlertOpen: true });
+  private onCancel = () => this.setState({ isAlertOpen: false });
+  private onConfirm = () => {
+    this.props.onDelete(this.props.question.id);
+    this.onCancel();
+  };
+
+  render() {
+    const { question } = this.props;
+
+    return (
+      <div className={`${Classes.CARD} ${Classes.ELEVATION_1}`} style={{ marginBottom: 10 }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <strong>{question.prompt}</strong>
+          <Button icon="trash" intent={Intent.DANGER} minimal onClick={this.onClick} />
+        </div>
+
+        <Tag minimal style={{ marginTop: 5 }}>
+          {question.questionType}
+        </Tag>
+
+        {question.questionType === 'multiple choice' && (
+          <ul>
+            {question.choices.map(choice => (
+              <li key={choice.id}>
+                {choice.text} {choice.correct && <Tag intent={Intent.SUCCESS}>correct</Tag>}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <Alert
+          isOpen={this.state.isAlertOpen}
+          onConfirm={this.onConfirm}
+          onCancel={this.onCancel}
+          confirmButtonText="Delete"
+          cancelButtonText="Cancel"
+          intent={Intent.DANGER}
+        >
+          <p>Are you sure you want to delete this question?</p>
+        </Alert>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/quiz/ShowQuizQuestions.tsx
+++ b/frontend/src/components/quiz/ShowQuizQuestions.tsx
@@ -1,0 +1,101 @@
+import * as React from 'react';
+import { Classes, H3, H5, Intent, NonIdealState, Spinner } from '@blueprintjs/core';
+import { ComponentType } from 'react';
+import { connect } from 'react-redux';
+import { createSelector } from 'reselect';
+import { ApplicationState } from '../../state/ApplicationState';
+import { getAccessToken } from '../../state/Selectors';
+import { QuizApi } from '../../api';
+import { CreateQuizQuestionData, ManageQuizQuestion } from '../../models/QuizQuestion';
+import { CreateQuizQuestionForm } from './CreateQuizQuestionForm';
+import { ExistingQuizQuestion } from './ExistingQuizQuestion';
+import { AppToaster } from '../../services/AppToaster';
+
+type DispatchProps = {
+  readonly accessToken: string;
+};
+
+type State = {
+  readonly loading: boolean;
+  readonly error: string | null;
+  readonly questions: ManageQuizQuestion[];
+};
+
+class ShowQuizQuestionsComponent extends React.PureComponent<DispatchProps, State> {
+  state: State = {
+    loading: true,
+    error: null,
+    questions: [],
+  };
+
+  componentDidMount() {
+    this.onRefresh();
+  }
+
+  private onRefresh = () =>
+    QuizApi.fetchQuizQuestionsForManagement(this.props.accessToken)
+      .then(questions => this.setState({ questions, loading: false, error: null }))
+      .catch(err => {
+        console.error(err);
+        this.setState({ loading: false, error: 'Unable to load quiz questions' });
+      });
+
+  private onSubmit = (question: CreateQuizQuestionData): Promise<boolean> =>
+    QuizApi.createQuizQuestion(question, this.props.accessToken)
+      .then(() => {
+        AppToaster.show({ message: 'Created new question', intent: Intent.SUCCESS });
+        return this.onRefresh().then(() => true);
+      })
+      .catch(() => {
+        AppToaster.show({ message: 'Error creating question', intent: Intent.DANGER });
+        return false;
+      });
+
+  private onDelete = (id: number) =>
+    QuizApi.deleteQuizQuestion(id, this.props.accessToken)
+      .then(() => {
+        AppToaster.show({ message: 'Question deleted', intent: Intent.SUCCESS });
+        this.setState(prev => ({ questions: prev.questions.filter(q => q.id !== id) }));
+      })
+      .catch(() => {
+        AppToaster.show({ message: 'Error deleting question', intent: Intent.DANGER });
+      });
+
+  render() {
+    let top;
+    if (this.state.error) {
+      top = (
+        <div className={`${Classes.CALLOUT} ${Classes.INTENT_DANGER}`}>
+          <H5>Error: {this.state.error}</H5>
+        </div>
+      );
+    } else if (this.state.loading) {
+      top = <NonIdealState icon={<Spinner />} title="Loading...." />;
+    } else if (this.state.questions.length === 0) {
+      top = <NonIdealState icon="help" title="No questions setup" />;
+    } else {
+      top = (
+        <div>
+          {this.state.questions.map(question => (
+            <ExistingQuizQuestion question={question} key={question.id} onDelete={this.onDelete} />
+          ))}
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        {top}
+
+        <H3>Create new question</H3>
+        <CreateQuizQuestionForm onSubmit={this.onSubmit} />
+      </div>
+    );
+  }
+}
+
+const stateSelector = createSelector<ApplicationState, string | null, DispatchProps>(getAccessToken, accessToken => ({
+  accessToken: accessToken || 'NO ACCESS TOKEN IN STORE',
+}));
+
+export const ShowQuizQuestions: ComponentType = connect<DispatchProps, {}, {}>(stateSelector)(ShowQuizQuestionsComponent);

--- a/frontend/src/components/quiz/index.tsx
+++ b/frontend/src/components/quiz/index.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { RouteComponentProps } from 'react-router';
+import { H1 } from '@blueprintjs/core';
+import { ShowQuizQuestions } from './ShowQuizQuestions';
+
+export class QuizManagementPage extends React.PureComponent<RouteComponentProps<any>> {
+  render() {
+    return (
+      <div>
+        <H1>Host Application Quiz</H1>
+        <div style={{ margin: 30 }}>
+          <ShowQuizQuestions />
+        </div>
+      </div>
+    );
+  }
+}

--- a/frontend/src/models/HostApplication.ts
+++ b/frontend/src/models/HostApplication.ts
@@ -1,0 +1,29 @@
+export type HostApplicationStatus = 'pending' | 'approved' | 'declined';
+
+export type HostApplication = {
+  readonly id: number;
+  readonly username: string;
+  readonly created: string;
+  readonly status: HostApplicationStatus;
+  readonly reviewedBy: string | null;
+  readonly reviewedAt: string | null;
+  readonly reviewReason: string | null;
+};
+
+export type HostApplicationAnswer = {
+  readonly questionPrompt: string;
+  readonly questionType: 'multiple choice' | 'text';
+  readonly choiceText: string | null;
+  readonly choiceCorrect: boolean | null;
+  readonly textAnswer: string | null;
+};
+
+export type HostApplicationDetails = HostApplication & {
+  readonly answers: HostApplicationAnswer[];
+};
+
+export type SubmitAnswerData = {
+  readonly questionId: number;
+  readonly choiceId?: number;
+  readonly textAnswer?: string;
+};

--- a/frontend/src/models/Match.tsx
+++ b/frontend/src/models/Match.tsx
@@ -29,4 +29,5 @@ export type Match = {
   approvedBy: string | null;
   hostingName: string | null;
   tournament: boolean;
+  roles: Array<string>;
 };

--- a/frontend/src/models/QuizQuestion.ts
+++ b/frontend/src/models/QuizQuestion.ts
@@ -1,0 +1,37 @@
+export type QuestionType = 'multiple choice' | 'text';
+
+export type QuizChoice = {
+  readonly id: number;
+  readonly text: string;
+};
+
+export type QuizQuestion = {
+  readonly id: number;
+  readonly prompt: string;
+  readonly questionType: QuestionType;
+  readonly choices: QuizChoice[];
+};
+
+export type ManageQuizChoice = QuizChoice & {
+  readonly correct: boolean;
+};
+
+export type ManageQuizQuestion = {
+  readonly id: number;
+  readonly prompt: string;
+  readonly questionType: QuestionType;
+  readonly createdBy: string;
+  readonly created: string;
+  readonly choices: ManageQuizChoice[];
+};
+
+export type CreateQuizChoiceData = {
+  readonly text: string;
+  readonly correct: boolean;
+};
+
+export type CreateQuizQuestionData = {
+  readonly prompt: string;
+  readonly questionType: QuestionType;
+  readonly choices: CreateQuizChoiceData[];
+};

--- a/src/main/resources/db/migration/V20__Add_Host_Applications.sql
+++ b/src/main/resources/db/migration/V20__Add_Host_Applications.sql
@@ -1,0 +1,12 @@
+CREATE TABLE host_applications (
+  id BIGSERIAL NOT NULL PRIMARY KEY,
+  username TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created TIMESTAMP NOT NULL,
+  status TEXT NOT NULL,
+  reviewedBy TEXT,
+  reviewedAt TIMESTAMP
+);
+
+CREATE INDEX ON host_applications (created);
+CREATE INDEX ON host_applications (status);

--- a/src/main/resources/db/migration/V21__Add_Quiz_Questions.sql
+++ b/src/main/resources/db/migration/V21__Add_Quiz_Questions.sql
@@ -1,0 +1,30 @@
+ALTER TABLE host_applications ALTER COLUMN content DROP NOT NULL;
+
+CREATE TABLE quiz_questions (
+  id BIGSERIAL NOT NULL PRIMARY KEY,
+  prompt TEXT NOT NULL,
+  type TEXT NOT NULL,
+  createdBy TEXT NOT NULL,
+  created TIMESTAMP NOT NULL
+);
+
+CREATE TABLE quiz_question_choices (
+  id BIGSERIAL NOT NULL PRIMARY KEY,
+  questionId BIGINT NOT NULL REFERENCES quiz_questions (id) ON DELETE CASCADE,
+  text TEXT NOT NULL,
+  correct BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX ON quiz_question_choices (questionId);
+
+CREATE TABLE host_application_answers (
+  id BIGSERIAL NOT NULL PRIMARY KEY,
+  applicationId BIGINT NOT NULL REFERENCES host_applications (id) ON DELETE CASCADE,
+  questionPrompt TEXT NOT NULL,
+  questionType TEXT NOT NULL,
+  choiceText TEXT,
+  choiceCorrect BOOLEAN,
+  textAnswer TEXT
+);
+
+CREATE INDEX ON host_application_answers (applicationId);

--- a/src/main/resources/db/migration/V22__Add_Host_Application_Review_Reason.sql
+++ b/src/main/resources/db/migration/V22__Add_Host_Application_Review_Reason.sql
@@ -1,0 +1,1 @@
+ALTER TABLE host_applications ADD COLUMN reviewReason TEXT;

--- a/src/main/scala/gg/uhc/hosts/database/Database.scala
+++ b/src/main/scala/gg/uhc/hosts/database/Database.scala
@@ -119,6 +119,49 @@ class Database(transactor: Transactor[IO], system: ActorSystem @@ DatabaseSystem
     case _ => raw(_ => Map.empty[String, List[String]])
   }
 
+  def getRecentHostApplications: ConnectionIO[List[HostApplicationRow]] =
+    queries.getRecentHostApplications.to[List]
+
+  def getHostApplication(id: Long): ConnectionIO[Option[HostApplicationRow]] =
+    queries.getHostApplication(id).option
+
+  def getPendingHostApplicationForUsername(username: String): ConnectionIO[Option[HostApplicationRow]] =
+    queries.getPendingHostApplicationForUsername(username).option
+
+  def reviewHostApplication(id: Long, status: String, reviewer: String, reason: Option[String]): ConnectionIO[Boolean] =
+    queries.reviewHostApplication(id, status, reviewer, reason).run.map(_ > 0)
+
+  def getHostApplicationAnswers(applicationId: Long): ConnectionIO[List[HostApplicationAnswerRow]] =
+    queries.getHostApplicationAnswers(applicationId).to[List]
+
+  def submitHostApplication(username: String, answers: List[HostApplicationAnswerRow]): ConnectionIO[Long] =
+    for {
+      id <- queries.createHostApplication(username).withUniqueGeneratedKeys[Long]("id")
+      _ <- answers.foldLeft(delay(())) { (acc, answer) =>
+        acc.flatMap(_ => queries.createHostApplicationAnswer(id, answer).run.map(_ => ()))
+      }
+    } yield id
+
+  def getAllQuizQuestions: ConnectionIO[List[QuizQuestionRow]] =
+    queries.getAllQuizQuestions.to[List]
+
+  def getQuizQuestionChoices(questionIds: List[Long]): ConnectionIO[List[QuizQuestionChoiceRow]] =
+    questionIds match {
+      case a +: as => queries.getQuizQuestionChoices(NonEmptyList(a, as)).to[List]
+      case _       => delay(List.empty[QuizQuestionChoiceRow])
+    }
+
+  def createQuizQuestionWithChoices(question: QuizQuestionRow, choices: List[(String, Boolean)]): ConnectionIO[Long] =
+    for {
+      id <- queries.createQuizQuestion(question).withUniqueGeneratedKeys[Long]("id")
+      _ <- choices.foldLeft(delay(())) { (acc, choice) =>
+        acc.flatMap(_ => queries.createQuizQuestionChoice(id, choice._1, choice._2).run.map(_ => ()))
+      }
+    } yield id
+
+  def deleteQuizQuestion(id: Long): ConnectionIO[Int] =
+    queries.deleteQuizQuestion(id).run
+
   def addPermission(username: String, permission: String, modifier: String): ConnectionIO[Boolean] =
     for {
       inserted <- queries.addPermission(username = username, permission = permission).run.map(_ > 0)

--- a/src/main/scala/gg/uhc/hosts/database/HostApplicationAnswerRow.scala
+++ b/src/main/scala/gg/uhc/hosts/database/HostApplicationAnswerRow.scala
@@ -1,0 +1,10 @@
+package gg.uhc.hosts.database
+
+case class HostApplicationAnswerRow(
+    id: Long,
+    applicationId: Long,
+    questionPrompt: String,
+    questionType: String,
+    choiceText: Option[String],
+    choiceCorrect: Option[Boolean],
+    textAnswer: Option[String])

--- a/src/main/scala/gg/uhc/hosts/database/HostApplicationRow.scala
+++ b/src/main/scala/gg/uhc/hosts/database/HostApplicationRow.scala
@@ -1,0 +1,12 @@
+package gg.uhc.hosts.database
+
+import java.time.Instant
+
+case class HostApplicationRow(
+    id: Long,
+    username: String,
+    created: Instant,
+    status: String,
+    reviewedBy: Option[String],
+    reviewedAt: Option[Instant],
+    reviewReason: Option[String])

--- a/src/main/scala/gg/uhc/hosts/database/Queries.scala
+++ b/src/main/scala/gg/uhc/hosts/database/Queries.scala
@@ -16,6 +16,89 @@ import cats.data.NonEmptyList
 class Queries(logger: LogHandler) {
   private[this] implicit val logHandler: LogHandler = logger
 
+  def createHostApplication(username: String): Update0 =
+    sql"""
+      INSERT INTO host_applications (username, created, status)
+      VALUES ($username, ${Instant.now()}, 'pending')
+    """.update
+
+  def getRecentHostApplications: Query0[HostApplicationRow] =
+    sql"""
+      SELECT id, username, created, status, reviewedBy, reviewedAt, reviewReason
+      FROM host_applications
+      ORDER BY created DESC
+      LIMIT 50
+    """.query[HostApplicationRow]
+
+  def getHostApplication(id: Long): Query0[HostApplicationRow] =
+    sql"""
+      SELECT id, username, created, status, reviewedBy, reviewedAt, reviewReason
+      FROM host_applications
+      WHERE id = $id
+    """.query[HostApplicationRow]
+
+  def getPendingHostApplicationForUsername(username: String): Query0[HostApplicationRow] =
+    sql"""
+      SELECT id, username, created, status, reviewedBy, reviewedAt, reviewReason
+      FROM host_applications
+      WHERE username = $username AND status = 'pending'
+    """.query[HostApplicationRow]
+
+  def reviewHostApplication(id: Long, status: String, reviewer: String, reason: Option[String]): Update0 =
+    sql"""
+      UPDATE host_applications
+      SET status = $status, reviewedBy = $reviewer, reviewedAt = ${Instant.now()}, reviewReason = $reason
+      WHERE id = $id AND status = 'pending'
+    """.update
+
+  def createQuizQuestion(question: QuizQuestionRow): Update0 =
+    sql"""
+      INSERT INTO quiz_questions (prompt, type, createdBy, created)
+      VALUES (${question.prompt}, ${question.questionType}, ${question.createdBy}, ${question.created})
+    """.update
+
+  def createQuizQuestionChoice(questionId: Long, text: String, correct: Boolean): Update0 =
+    sql"""
+      INSERT INTO quiz_question_choices (questionId, text, correct)
+      VALUES ($questionId, $text, $correct)
+    """.update
+
+  val getAllQuizQuestions: Query0[QuizQuestionRow] =
+    sql"""
+      SELECT id, prompt, type, createdBy, created
+      FROM quiz_questions
+      ORDER BY id ASC
+    """.query[QuizQuestionRow]
+
+  def getQuizQuestionChoices(questionIds: NonEmptyList[Long]): Query0[QuizQuestionChoiceRow] =
+    (sql"""
+      SELECT id, questionId, text, correct
+      FROM quiz_question_choices
+      WHERE """ ++ Fragments.in(fr"questionId", questionIds) ++ sql""" ORDER BY id ASC""")
+      .query[QuizQuestionChoiceRow]
+
+  def deleteQuizQuestion(id: Long): Update0 =
+    sql"""
+      DELETE FROM quiz_questions
+      WHERE id = $id
+    """.update
+
+  def createHostApplicationAnswer(applicationId: Long, answer: HostApplicationAnswerRow): Update0 =
+    sql"""
+      INSERT INTO host_application_answers
+        (applicationId, questionPrompt, questionType, choiceText, choiceCorrect, textAnswer)
+      VALUES
+        ($applicationId, ${answer.questionPrompt}, ${answer.questionType}, ${answer.choiceText}, ${answer.choiceCorrect}, ${answer.textAnswer})
+    """.update
+
+  def getHostApplicationAnswers(applicationId: Long): Query0[HostApplicationAnswerRow] =
+    sql"""
+      SELECT id, applicationId, questionPrompt, questionType, choiceText, choiceCorrect, textAnswer
+      FROM host_application_answers
+      WHERE applicationId = $applicationId
+      ORDER BY id ASC
+    """.query[HostApplicationAnswerRow]
+
   def removeMatch(id: Long, reason: String, remover: String): Update0 =
     sql"""
       UPDATE matches

--- a/src/main/scala/gg/uhc/hosts/database/QuizQuestionChoiceRow.scala
+++ b/src/main/scala/gg/uhc/hosts/database/QuizQuestionChoiceRow.scala
@@ -1,0 +1,3 @@
+package gg.uhc.hosts.database
+
+case class QuizQuestionChoiceRow(id: Long, questionId: Long, text: String, correct: Boolean)

--- a/src/main/scala/gg/uhc/hosts/database/QuizQuestionRow.scala
+++ b/src/main/scala/gg/uhc/hosts/database/QuizQuestionRow.scala
@@ -1,0 +1,5 @@
+package gg.uhc.hosts.database
+
+import java.time.Instant
+
+case class QuizQuestionRow(id: Long, prompt: String, questionType: String, createdBy: String, created: Instant)

--- a/src/main/scala/gg/uhc/hosts/endpoints/ApiRoute.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/ApiRoute.scala
@@ -8,6 +8,7 @@ import gg.uhc.hosts.Instrumented
 import gg.uhc.hosts.endpoints.alerts.AlertsRoute
 import gg.uhc.hosts.endpoints.docs.DocsRoute
 import gg.uhc.hosts.endpoints.hosts.HostsRoute
+import gg.uhc.hosts.endpoints.hostapplications.{HostApplicationsRoute, QuizRoute}
 import gg.uhc.hosts.endpoints.key.KeyRoute
 import gg.uhc.hosts.endpoints.matches.MatchesRoute
 import gg.uhc.hosts.endpoints.modifiers.ModifiersRoute
@@ -25,6 +26,8 @@ class ApiRoute(
     keyRoute: KeyRoute,
     docsRoute: DocsRoute,
     hostsRoute: HostsRoute,
+    hostApplicationsRoute: HostApplicationsRoute,
+    quizRoute: QuizRoute,
     ublRoute: UblRoute,
     alertsRoute: AlertsRoute,
     usersRoute: UsersRoute,
@@ -43,6 +46,8 @@ class ApiRoute(
           pathPrefix("rules")(rulesRoute()),
           pathPrefix("matches")(matchesRoute()),
           pathPrefix("hosts")(hostsRoute()),
+          pathPrefix("host-applications")(hostApplicationsRoute()),
+          pathPrefix("quiz")(quizRoute()),
           pathPrefix("permissions")(permissionsRoute()),
           pathPrefix("key")(keyRoute()),
           pathPrefix("docs")(docsRoute()),

--- a/src/main/scala/gg/uhc/hosts/endpoints/EndpointsModule.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/EndpointsModule.scala
@@ -5,7 +5,7 @@ import com.softwaremill.macwire.wire
 import gg.uhc.hosts.database.Database
 import gg.uhc.hosts.endpoints.alerts.{AlertsRoute, CreateAlertRule, DeleteAlertRule, GetAllAlertRules}
 import gg.uhc.hosts.endpoints.assets.AssetsRoute
-import gg.uhc.hosts.endpoints.authentication.{Authenticate, AuthenticateCallback, AuthenticateRefresh, AuthenticationRoute, FakeAuthenticate}
+import gg.uhc.hosts.endpoints.authentication.{Authenticate, AuthenticateCallback, AuthenticateRefresh, AuthenticationRoute}
 import gg.uhc.hosts.endpoints.docs.DocsRoute
 import gg.uhc.hosts.endpoints.frontend.FrontendRoute
 import gg.uhc.hosts.endpoints.hosts.{GetHostingHistory, HostsRoute}

--- a/src/main/scala/gg/uhc/hosts/endpoints/EndpointsModule.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/EndpointsModule.scala
@@ -5,10 +5,22 @@ import com.softwaremill.macwire.wire
 import gg.uhc.hosts.database.Database
 import gg.uhc.hosts.endpoints.alerts.{AlertsRoute, CreateAlertRule, DeleteAlertRule, GetAllAlertRules}
 import gg.uhc.hosts.endpoints.assets.AssetsRoute
-import gg.uhc.hosts.endpoints.authentication.{Authenticate, AuthenticateCallback, AuthenticateRefresh, AuthenticationRoute}
+import gg.uhc.hosts.endpoints.authentication.{Authenticate, AuthenticateCallback, AuthenticateRefresh, AuthenticationRoute, FakeAuthenticate}
 import gg.uhc.hosts.endpoints.docs.DocsRoute
 import gg.uhc.hosts.endpoints.frontend.FrontendRoute
 import gg.uhc.hosts.endpoints.hosts.{GetHostingHistory, HostsRoute}
+import gg.uhc.hosts.endpoints.hostapplications.{
+  CreateHostApplication,
+  CreateQuizQuestion,
+  DeleteQuizQuestion,
+  GetHostApplicationDetails,
+  GetHostApplications,
+  GetQuizQuestions,
+  GetQuizQuestionsForManagement,
+  HostApplicationsRoute,
+  QuizRoute,
+  ReviewHostApplication
+}
 import gg.uhc.hosts.endpoints.key.{GetApiKey, KeyRoute, RegenerateApiKey}
 import gg.uhc.hosts.endpoints.matches._
 import gg.uhc.hosts.endpoints.modifiers.{CreateModifier, DeleteModifier, ListModifiers, ModifiersRoute}
@@ -49,6 +61,14 @@ trait EndpointsModule extends RedditModule {
   lazy val approveMatch: ApproveMatch           = wire[ApproveMatch]
   lazy val getCurrentUbl: GetCurrentUbl         = wire[GetCurrentUbl]
   lazy val getHostingHistory: GetHostingHistory = wire[GetHostingHistory]
+  lazy val getHostApplications: GetHostApplications = wire[GetHostApplications]
+  lazy val getHostApplicationDetails: GetHostApplicationDetails = wire[GetHostApplicationDetails]
+  lazy val createHostApplication: CreateHostApplication = wire[CreateHostApplication]
+  lazy val reviewHostApplication: ReviewHostApplication = wire[ReviewHostApplication]
+  lazy val getQuizQuestions: GetQuizQuestions = wire[GetQuizQuestions]
+  lazy val getQuizQuestionsForManagement: GetQuizQuestionsForManagement = wire[GetQuizQuestionsForManagement]
+  lazy val createQuizQuestion: CreateQuizQuestion = wire[CreateQuizQuestion]
+  lazy val deleteQuizQuestion: DeleteQuizQuestion = wire[DeleteQuizQuestion]
   lazy val createUblEntry: CreateUblEntry       = wire[CreateUblEntry]
   lazy val getUblForUuid: GetUblForUuid         = wire[GetUblForUuid]
   lazy val usernameSearch: UsernameSearch       = wire[UsernameSearch]
@@ -75,6 +95,8 @@ trait EndpointsModule extends RedditModule {
   lazy val apiRoute: ApiRoute                       = wire[ApiRoute]
   lazy val ublRoute: UblRoute                       = wire[UblRoute]
   lazy val hostsRoute: HostsRoute                   = wire[HostsRoute]
+  lazy val hostApplicationsRoute: HostApplicationsRoute = wire[HostApplicationsRoute]
+  lazy val quizRoute: QuizRoute                     = wire[QuizRoute]
   lazy val alertsRoute: AlertsRoute                 = wire[AlertsRoute]
   lazy val usersRoute: UsersRoute                   = wire[UsersRoute]
   lazy val modifiersRoute: ModifiersRoute           = wire[ModifiersRoute]

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/CreateHostApplication.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/CreateHostApplication.scala
@@ -1,0 +1,100 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive0, Route}
+import gg.uhc.hosts.CustomJsonCodec
+import gg.uhc.hosts.database.{Database, HostApplicationAnswerRow, HostApplicationRow, QuizQuestionChoiceRow, QuizQuestionRow}
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+class CreateHostApplication(database: Database, customDirectives: CustomDirectives) {
+  import CustomJsonCodec._
+  import customDirectives._
+
+  case class AnswerPayload(questionId: Long, choiceId: Option[Long], textAnswer: Option[String])
+  case class CreateHostApplicationPayload(answers: List[AnswerPayload])
+
+  private[this] def validateApplicant(username: String): Directive0 =
+    requireSucessfulQuery(database.getPermissions(username)).flatMap { permissions: List[String] =>
+      validate(
+        !permissions.contains("host") && !permissions.contains("trial host"),
+        "Hosts cannot submit applications"
+      ) & validate(!permissions.contains("hosting banned"), "Banned users cannot submit applications")
+    } & requireSucessfulQuery(database.getPendingHostApplicationForUsername(username)).flatMap {
+      existing: Option[HostApplicationRow] =>
+        validate(existing.isEmpty, "You already have a pending application")
+    }
+
+  private[this] def buildAnswers(
+      payload: List[AnswerPayload],
+      questions: List[QuizQuestionRow],
+      choices: List[QuizQuestionChoiceRow]
+  ): Either[String, List[HostApplicationAnswerRow]] =
+    if (questions.isEmpty) {
+      Left("There are no quiz questions configured")
+    } else if (payload.map(_.questionId).distinct.size != questions.size || payload.size != questions.size) {
+      Left("You must answer every question exactly once")
+    } else {
+      val choicesByQuestion = choices.groupBy(_.questionId)
+      val answersByQuestion = payload.map(a => a.questionId -> a).toMap
+
+      questions.foldLeft[Either[String, List[HostApplicationAnswerRow]]](Right(Nil)) { (acc, question) =>
+        acc.flatMap { built =>
+          answersByQuestion.get(question.id) match {
+            case Some(answer) if question.questionType == "text" =>
+              answer.textAnswer.map(_.trim).filter(_.nonEmpty) match {
+                case Some(text) =>
+                  Right(
+                    built :+ HostApplicationAnswerRow(
+                      id = -1,
+                      applicationId = -1,
+                      questionPrompt = question.prompt,
+                      questionType = question.questionType,
+                      choiceText = None,
+                      choiceCorrect = None,
+                      textAnswer = Some(text)
+                    ))
+                case None => Left(s"Missing answer for question: ${question.prompt}")
+              }
+            case Some(answer) if question.questionType == "multiple choice" =>
+              answer.choiceId.flatMap(id => choicesByQuestion.getOrElse(question.id, Nil).find(_.id == id)) match {
+                case Some(choice) =>
+                  Right(
+                    built :+ HostApplicationAnswerRow(
+                      id = -1,
+                      applicationId = -1,
+                      questionPrompt = question.prompt,
+                      questionType = question.questionType,
+                      choiceText = Some(choice.text),
+                      choiceCorrect = Some(choice.correct),
+                      textAnswer = None
+                    ))
+                case None => Left(s"Invalid choice for question: ${question.prompt}")
+              }
+            case _ => Left(s"Missing answer for question: ${question.prompt}")
+          }
+        }
+      }
+    }
+
+  def apply(): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      requireAuthentication { session =>
+        validateApplicant(session.username) {
+          entity(as[CreateHostApplicationPayload]) { payload =>
+            requireSucessfulQuery(database.getAllQuizQuestions) { questions =>
+              requireSucessfulQuery(database.getQuizQuestionChoices(questions.map(_.id))) { choices =>
+                buildAnswers(payload.answers, questions, choices) match {
+                  case Left(error) => complete(StatusCodes.BadRequest -> error)
+                  case Right(answers) =>
+                    requireSucessfulQuery(database.submitHostApplication(session.username, answers)) { id =>
+                      complete(StatusCodes.Created -> Map("id" -> id))
+                    }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/CreateQuizQuestion.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/CreateQuizQuestion.scala
@@ -1,0 +1,54 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.{Directive0, Route}
+import gg.uhc.hosts.CustomJsonCodec
+import gg.uhc.hosts.database.{Database, QuizQuestionRow}
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+import java.time.Instant
+
+class CreateQuizQuestion(database: Database, customDirectives: CustomDirectives) {
+  import CustomJsonCodec._
+  import customDirectives._
+
+  case class ChoicePayload(text: String, correct: Boolean)
+  case class CreateQuizQuestionPayload(prompt: String, questionType: String, choices: List[ChoicePayload])
+
+  private[this] val validTypes = Set("multiple choice", "text")
+
+  private[this] def validatePayload(payload: CreateQuizQuestionPayload): Directive0 =
+    validate(payload.prompt.trim.nonEmpty, "Prompt cannot be empty") &
+      validate(validTypes.contains(payload.questionType), "Invalid question type") &
+      validate(payload.choices.forall(_.text.trim.nonEmpty), "Choices cannot be empty") &
+      validate(
+        payload.questionType != "multiple choice" || (payload.choices.size >= 2 && payload.choices.count(_.correct) == 1),
+        "Multiple choice questions require at least 2 choices with exactly one correct answer"
+      ) &
+      validate(payload.questionType != "text" || payload.choices.isEmpty, "Text questions cannot have choices")
+
+  def apply(): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      requireAuthentication { session =>
+        requirePermission("hosting advisor", session.username) {
+          entity(as[CreateQuizQuestionPayload]) { payload =>
+            validatePayload(payload) {
+              val question = QuizQuestionRow(
+                id = -1,
+                prompt = payload.prompt.trim,
+                questionType = payload.questionType,
+                createdBy = session.username,
+                created = Instant.now()
+              )
+              val choices = payload.choices.map(c => c.text.trim -> c.correct)
+
+              requireSucessfulQuery(database.createQuizQuestionWithChoices(question, choices)) { id =>
+                complete(StatusCodes.Created -> Map("id" -> id))
+              }
+            }
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/DeleteQuizQuestion.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/DeleteQuizQuestion.scala
@@ -1,0 +1,22 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import gg.uhc.hosts.database.Database
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+class DeleteQuizQuestion(database: Database, customDirectives: CustomDirectives) {
+  import customDirectives._
+
+  def apply(id: Long): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      requireAuthentication { session =>
+        requirePermission("hosting advisor", session.username) {
+          requireSucessfulQuery(database.deleteQuizQuestion(id)) { _ =>
+            complete(StatusCodes.NoContent)
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetHostApplicationDetails.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetHostApplicationDetails.scala
@@ -1,0 +1,66 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import gg.uhc.hosts.CustomJsonCodec
+import gg.uhc.hosts.database.Database
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+import java.time.Instant
+
+class GetHostApplicationDetails(database: Database, customDirectives: CustomDirectives) {
+  import CustomJsonCodec._
+  import customDirectives._
+
+  case class AnswerResponse(
+      questionPrompt: String,
+      questionType: String,
+      choiceText: Option[String],
+      choiceCorrect: Option[Boolean],
+      textAnswer: Option[String])
+
+  case class HostApplicationDetailsResponse(
+      id: Long,
+      username: String,
+      created: Instant,
+      status: String,
+      reviewedBy: Option[String],
+      reviewedAt: Option[Instant],
+      reviewReason: Option[String],
+      answers: List[AnswerResponse])
+
+  def apply(id: Long): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      optionalAuthentication { session =>
+        val canReview = session.exists(_.permissions.contains("hosting advisor"))
+
+        requireSucessfulQuery(database.getHostApplication(id)) {
+          case None => complete(StatusCodes.NotFound)
+          case Some(application) =>
+            requireSucessfulQuery(database.getHostApplicationAnswers(id)) { answers =>
+              complete(
+                HostApplicationDetailsResponse(
+                  id = application.id,
+                  username = application.username,
+                  created = application.created,
+                  status = application.status,
+                  reviewedBy = application.reviewedBy,
+                  reviewedAt = application.reviewedAt,
+                  reviewReason = application.reviewReason,
+                  answers = answers.map(
+                    answer =>
+                      AnswerResponse(
+                        questionPrompt = answer.questionPrompt,
+                        questionType = answer.questionType,
+                        choiceText = answer.choiceText,
+                        choiceCorrect = if (canReview) answer.choiceCorrect else None,
+                        textAnswer = answer.textAnswer
+                    ))
+                )
+              )
+            }
+        }
+      }
+    }
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetHostApplications.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetHostApplications.scala
@@ -1,0 +1,19 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import gg.uhc.hosts.CustomJsonCodec
+import gg.uhc.hosts.database.Database
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+class GetHostApplications(database: Database, customDirectives: CustomDirectives) {
+  import CustomJsonCodec._
+  import customDirectives._
+
+  def apply(): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      requireSucessfulQuery(database.getRecentHostApplications) { applications =>
+        complete(applications)
+      }
+    }
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetQuizQuestions.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetQuizQuestions.scala
@@ -1,0 +1,33 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import gg.uhc.hosts.CustomJsonCodec
+import gg.uhc.hosts.database.Database
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+class GetQuizQuestions(database: Database, customDirectives: CustomDirectives) {
+  import CustomJsonCodec._
+  import customDirectives._
+
+  case class PublicChoice(id: Long, text: String)
+  case class PublicQuestion(id: Long, prompt: String, questionType: String, choices: List[PublicChoice])
+
+  def apply(): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      requireSucessfulQuery(database.getAllQuizQuestions) { questions =>
+        requireSucessfulQuery(database.getQuizQuestionChoices(questions.map(_.id))) { choices =>
+          val choicesByQuestion = choices.groupBy(_.questionId)
+          val result = questions.map { question =>
+            PublicQuestion(
+              id = question.id,
+              prompt = question.prompt,
+              questionType = question.questionType,
+              choices = choicesByQuestion.getOrElse(question.id, Nil).map(c => PublicChoice(c.id, c.text))
+            )
+          }
+          complete(result)
+        }
+      }
+    }
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetQuizQuestionsForManagement.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/GetQuizQuestionsForManagement.scala
@@ -1,0 +1,49 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import gg.uhc.hosts.CustomJsonCodec
+import gg.uhc.hosts.database.Database
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+import java.time.Instant
+
+class GetQuizQuestionsForManagement(database: Database, customDirectives: CustomDirectives) {
+  import CustomJsonCodec._
+  import customDirectives._
+
+  case class ManageChoice(id: Long, text: String, correct: Boolean)
+  case class ManageQuestion(
+      id: Long,
+      prompt: String,
+      questionType: String,
+      createdBy: String,
+      created: Instant,
+      choices: List[ManageChoice])
+
+  def apply(): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      requireAuthentication { session =>
+        requirePermission("hosting advisor", session.username) {
+          requireSucessfulQuery(database.getAllQuizQuestions) { questions =>
+            requireSucessfulQuery(database.getQuizQuestionChoices(questions.map(_.id))) { choices =>
+              val choicesByQuestion = choices.groupBy(_.questionId)
+              val result = questions.map { question =>
+                ManageQuestion(
+                  id = question.id,
+                  prompt = question.prompt,
+                  questionType = question.questionType,
+                  createdBy = question.createdBy,
+                  created = question.created,
+                  choices = choicesByQuestion
+                    .getOrElse(question.id, Nil)
+                    .map(c => ManageChoice(c.id, c.text, c.correct))
+                )
+              }
+              complete(result)
+            }
+          }
+        }
+      }
+    }
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/HostApplicationsRoute.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/HostApplicationsRoute.scala
@@ -1,0 +1,20 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.PathMatchers.LongNumber
+import akka.http.scaladsl.server.Route
+
+class HostApplicationsRoute(
+    getHostApplications: GetHostApplications,
+    getHostApplicationDetails: GetHostApplicationDetails,
+    createHostApplication: CreateHostApplication,
+    reviewHostApplication: ReviewHostApplication) {
+  def apply(): Route =
+    concat(
+      (get & pathEndOrSingleSlash)(getHostApplications()),
+      (post & pathEndOrSingleSlash)(createHostApplication()),
+      path(LongNumber / "approve")(id => post(reviewHostApplication(id, "approved"))),
+      path(LongNumber / "decline")(id => post(reviewHostApplication(id, "declined"))),
+      (get & path(LongNumber))(getHostApplicationDetails(_))
+    )
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/QuizRoute.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/QuizRoute.scala
@@ -1,0 +1,19 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.PathMatchers.LongNumber
+import akka.http.scaladsl.server.Route
+
+class QuizRoute(
+    getQuizQuestions: GetQuizQuestions,
+    getQuizQuestionsForManagement: GetQuizQuestionsForManagement,
+    createQuizQuestion: CreateQuizQuestion,
+    deleteQuizQuestion: DeleteQuizQuestion) {
+  def apply(): Route =
+    concat(
+      (get & path("manage"))(getQuizQuestionsForManagement()),
+      (get & pathEndOrSingleSlash)(getQuizQuestions()),
+      (post & pathEndOrSingleSlash)(createQuizQuestion()),
+      (delete & path(LongNumber))(deleteQuizQuestion(_))
+    )
+}

--- a/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/ReviewHostApplication.scala
+++ b/src/main/scala/gg/uhc/hosts/endpoints/hostapplications/ReviewHostApplication.scala
@@ -1,0 +1,46 @@
+package gg.uhc.hosts.endpoints.hostapplications
+
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+import gg.uhc.hosts.CustomJsonCodec
+import gg.uhc.hosts.database.Database
+import gg.uhc.hosts.endpoints.{CustomDirectives, EndpointRejectionHandler}
+
+class ReviewHostApplication(database: Database, customDirectives: CustomDirectives) {
+  import CustomJsonCodec._
+  import customDirectives._
+
+  case class ReviewPayload(reason: Option[String])
+
+  def apply(id: Long, status: String): Route =
+    handleRejections(EndpointRejectionHandler()) {
+      requireAuthentication { session =>
+        requirePermission("hosting advisor", session.username) {
+          entity(as[ReviewPayload]) { payload =>
+            val reason = payload.reason.map(_.trim).filter(_.nonEmpty)
+
+            validate(status != "declined" || reason.isDefined, "A reason is required to decline an application") {
+              requireSucessfulQuery(database.getHostApplication(id)) {
+                case None => complete(StatusCodes.NotFound)
+                case Some(application) if application.status != "pending" =>
+                  complete(StatusCodes.BadRequest -> "Application has already been reviewed")
+                case Some(application) =>
+                  val review = for {
+                    granted <- if (status == "approved")
+                      database.addPermission(application.username, "trial host", session.username)
+                    else doobie.free.connection.delay(true)
+                    updated <- database.reviewHostApplication(id, status, session.username, reason)
+                  } yield granted && updated
+
+                  requireSucessfulQuery(review) { updated =>
+                    if (updated) complete(StatusCodes.OK)
+                    else complete(StatusCodes.BadRequest -> "Application could not be reviewed")
+                  }
+              }
+            }
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
- Added a `HostStatus` component that shows a "Verified Host" or "Trial Host" tag next to a username, wired into match-details and match-row, with a small `fetchPermissionsForUser` API addition to support it
- New DB tables for host applications, quiz questions/choices and answers, plus a migration adding a `reviewReason` column for decline reasons
- Backend endpoints for listing/creating/reviewing host applications and for listing/creating/deleting quiz questions
- Hosts, trial hosts, and banned users can't submit applications, and you can only have one pending application at a time (reapplying after a decision is fine)
- Declining an application now requires a reason, which gets stored and shown on the application
- New public "Host Applications" list page and a separate "Apply to Host" page with the quiz form
- Your own application shows first in the list, and declined applications show the reason
- Advisor-only UI for managing quiz questions (create/list/delete)
- Added full OpenAPI docs for all the new host-applications and quiz endpoints